### PR TITLE
feat(order-service): add MongoDB integration and order persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/cloudwithj/orders/domain/Order.java
+++ b/src/main/java/com/cloudwithj/orders/domain/Order.java
@@ -1,0 +1,14 @@
+package com.cloudwithj.orders.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@RequiredArgsConstructor
+public class Order {
+
+    private final OrderId orderId;
+    private final BigDecimal amount;
+}

--- a/src/main/java/com/cloudwithj/orders/domain/OrderId.java
+++ b/src/main/java/com/cloudwithj/orders/domain/OrderId.java
@@ -1,0 +1,16 @@
+package com.cloudwithj.orders.domain;
+
+import java.util.UUID;
+
+public record OrderId(String value) {
+
+    public OrderId {
+        if(value == null || value.isBlank()) {
+            throw new IllegalArgumentException("OrderId cannot be null or blank");
+        }
+    }
+
+    public static OrderId generate() {
+        return new OrderId(UUID.randomUUID().toString());
+    }
+}

--- a/src/main/java/com/cloudwithj/orders/infrastructure/db/MongoOrderRepository.java
+++ b/src/main/java/com/cloudwithj/orders/infrastructure/db/MongoOrderRepository.java
@@ -1,0 +1,7 @@
+package com.cloudwithj.orders.infrastructure.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MongoOrderRepository extends MongoRepository<OrderDocument, String> {
+    OrderDocument findByOrderId(String orderId);
+}

--- a/src/main/java/com/cloudwithj/orders/infrastructure/db/OrderDocument.java
+++ b/src/main/java/com/cloudwithj/orders/infrastructure/db/OrderDocument.java
@@ -1,0 +1,26 @@
+package com.cloudwithj.orders.infrastructure.db;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "orders")
+public class OrderDocument {
+
+    @Id
+    private String id;
+    private String orderId;
+    private BigDecimal amount;
+
+    public OrderDocument(String orderId, BigDecimal amount) {
+        this.orderId = orderId;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/cloudwithj/orders/infrastructure/db/OrderMapper.java
+++ b/src/main/java/com/cloudwithj/orders/infrastructure/db/OrderMapper.java
@@ -1,0 +1,17 @@
+package com.cloudwithj.orders.infrastructure.db;
+
+import com.cloudwithj.orders.domain.Order;
+import com.cloudwithj.orders.domain.OrderId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderMapper {
+
+    public OrderDocument toDocument(Order order) {
+        return new OrderDocument(order.getOrderId().value(), order.getAmount());
+    }
+
+    public Order toDomain(OrderDocument document) {
+        return new Order(new OrderId(document.getOrderId()), document.getAmount());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,7 @@
 payment-service:
   url: http://localhost:8081
+
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/ordersDB


### PR DESCRIPTION
- Add `spring-boot-starter-data-mongodb` dependency to `pom.xml`
- Extend `MongoOrderRepository` with `MongoRepository`
- Introduce `OrderDocument` entity with MongoDB annotations
- Implement `OrderMapper` to map between domain and persistence layer
- Modify `OrderService` to persist orders in MongoDB after processing payment
- Add MongoDB connection settings in `application.yml`